### PR TITLE
config-chain without leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "license": "BSD",
   "dependencies": {
-    "config-chain": "~0.3.2",
+    "config-chain": "~1.1.3",
     "optimist": "~0.3.4"
   },
   "scripts": {


### PR DESCRIPTION
Updated config-chain version, because 0.3.2 has global variable leak [here](https://github.com/dominictarr/config-chain/commit/7085f5f01237419f1dadccfc3a0c49ba9a1aed33#L0L78)
