### PR TITLE
Add nested config objects support Closes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var argv = require('optimist').argv
 var cc   = require('config-chain')
 var join = require('path').join
+var deepExtend = require('deep-extend')
 var etc = '/etc'
 var win = process.platform === "win32"
 var home = win
@@ -12,17 +13,17 @@ module.exports = function (name, defaults) {
   if(!name)
     throw new Error('nameless configuration fail')
 
-  return cc(
-    argv,
-    cc.env(name + '_'),
-    argv.config,
-    join(home, '.' + name + 'rc'),
-    join(home, '.' + name, 'config'),
-    join(home, '.config', name),
-    join(home, '.config', name, 'config'),
-    win ? null : join(etc, name + 'rc'),
-    win ? null : join(etc, name, 'config'),
-    defaults
-  ).snapshot
 
+  return deepExtend.apply(null, [
+    typeof defaults === 'string' ? cc.json(defaults) : defaults,
+    win ? {} : cc.json(join(etc, name, 'config')),
+    win ? {} : cc.json(join(etc, name + 'rc')),
+    cc.json(join(home, '.config', name, 'config')),
+    cc.json(join(home, '.config', name)),
+    cc.json(join(home, '.' + name, 'config')),
+    cc.json(join(home, '.' + name + 'rc')),
+    cc.json(argv.config),
+    cc.env(name + '_'),
+    argv
+  ])
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "BSD",
   "dependencies": {
     "config-chain": "~0.3",
-    "optimist": "~0.3.4"
+    "optimist": "~0.3.4",
+    "deep-extend": "~0.2.5"
   },
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
Currently there is no support for environment variables. I could add support for `__` based splitting to `config-chain` or do env parsing in `rc` instead if its needed.

Other solution would be to use single underscore and support both old and new way. `__` would look kind of silly because you need single underscore anyway between the app name and conf key.
