### PR TITLE
Parse --config.* args as an object as done by optimist.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,18 @@ module.exports = function (name, defaults) {
     ? cc.json(defaults) : defaults
     ) || {}
 
+  var argvCopy,
+      argvConfig;
+
+  if (typeof argv.config !== 'object') {
+    argvCopy = argv
+    argvConfig = css.json(argv.config)
+  } else {
+    argvCopy = deepExtend({}, argv)
+    delete argvCopy.config
+    argvConfig = argv.config
+  }
+
   return deepExtend.apply(null, [
     defaults,
     win ? {} : cc.json(join(etc, name, 'config')),
@@ -25,9 +37,9 @@ module.exports = function (name, defaults) {
     cc.json(join(home, '.config', name)),
     cc.json(join(home, '.' + name, 'config')),
     cc.json(join(home, '.' + name + 'rc')),
-    cc.json(argv.config),
+    argvConfig,
     cc.env(name + '_'),
-    argv
+    argvCopy
   ])
 }
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@
 var n = 'rc'+Math.random()
 var assert = require('assert')
 
+process.argv.push('--config.foo=bar');
 process.env[n+'_envOption'] = 42
 
 var config = require('./')(n, {
@@ -12,3 +13,15 @@ console.log(config)
 
 assert.equal(config.option, true)
 assert.equal(config.envOption, 42)
+assert(!config.hasOwnProperty('config'));
+assert.equal(config.foo, 'bar')
+
+// ---
+
+config = require('./')(n, {
+  foo: 'baz'
+})
+
+console.log(config)
+assert(!config.hasOwnProperty('config'));
+assert.equal(config.foo, 'bar')


### PR DESCRIPTION
Little note:

The final rc object contains some unnecessary keys that are inserted by `optimist`: `$0` and `_`. Also, I'm not removing the `argv.config` if it's an `object`, causing the final rc to still have a `config` key.

To do both things I would need to do a `deepExtend` of the argv (because it should not be manipulated directly), remove the unnecessary things and use it instead of the argv.

Want me to do this?
Snapshot of the object in the test:

```
// Now:
{ option: true,
  foo: 'bar',
  envOption: '42',
  _: [],
  '$0': 'node ./test.js',
  config: { foo: 'bar' } }
// With the suggest change:
{ option: true,
  foo: 'bar',
  envOption: '42'
```
