### PR TITLE
Allow optional non-Optimist argv.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 #! /usr/bin/env node
-var argv = require('optimist').argv
 var cc   = require('./lib/utils')
 var join = require('path').join
 var deepExtend = require('deep-extend')
@@ -9,9 +8,11 @@ var home = win
            ? process.env.USERPROFILE
            : process.env.HOME
 
-module.exports = function (name, defaults) {
+module.exports = function (name, defaults, argv) {
   if(!name)
     throw new Error('nameless configuration fail')
+  if(!argv)
+    argv = require('optimist').argv
   defaults = (
       'string' === typeof defaults
     ? cc.json(defaults) : defaults

--- a/test/test.js
+++ b/test/test.js
@@ -12,3 +12,20 @@ console.log(config)
 
 assert.equal(config.option, true)
 assert.equal(config.envOption, 42)
+
+var customArgv = require('../')(n, {
+  option: true
+}, { // nopt-like argv
+  option: false,
+  envOption: 24,
+  argv: {
+    remain: [],
+    cooked: ['--no-option', '--envOption', '24'],
+    original: ['--no-option', '--envOption=24']
+  }
+})
+
+console.log(customArgv)
+
+assert.equal(customArgv.option, false)
+assert.equal(customArgv.envOption, 24)


### PR DESCRIPTION
This allows other arg parsers (e.g., `nopt` or any other argument parser that gives you a hash of options) to provide the argv that `rc` consumes. If no custom `argv` are provided, it trundles along as before with `optimist`.
