### PR TITLE
Clarify docs, and fix spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,35 @@
 # rc
 
-the non configurable configuration loader for lazy people.
+The non-configurable configuration loader for lazy people.
 
 # Usage
 
-the only option is to pass rc the name of your app, and your default configuration.
+The only option is to pass rc the name of your app, and your default configuration.
 
 ```
-  var rc = require('rc')(appname, {
-    //defaults go here.
-    port: 2468
-  })
+var rc = require('rc')(appname, {
+  //defaults go here.
+  port: 2468
+})
 ```
 
 # Standards
 
-Given your application name, rc will look in all the obvious places for configuration.
-
+Given your application name (`appname`), rc will look in all the obvious places for configuration.
 
   * command line arguments (parsed by optimist)
-  * enviroment variables prefixed with ${APPNAME}_
+  * environment variables prefixed with `${appname}_`
   * if you passed an option `--config file` then from that file
-  * a local `.${APPNAME}rc` or the first found looking in `./ ../ ../../ ../../../` etc. 
-  * `$HOME/.${APPNAME}rc`
-  * `$HOME/.${APPNAME}/config`
-  * `$HOME/.config/${APPNAME}`
-  * `$HOME/.config/${APPNAME}/config`
-  * `/etc/${APPNAME}rc`
-  * `/etc/${APPNAME}/config`
+  * a local `.${appname}rc` or the first found looking in `./ ../ ../../ ../../../` etc. 
+  * `$HOME/.${appname}rc`
+  * `$HOME/.${appname}/config`
+  * `$HOME/.config/${appname}`
+  * `$HOME/.config/${appname}/config`
+  * `/etc/${appname}rc`
+  * `/etc/${appname}/config`
   * the defaults object you passed in.
 
-All configuration sources that where found will be flattened into one object,
+All configuration sources that were found will be flattened into one object,
 so that sources earlier in this list override later ones.
 
 # Formats


### PR DESCRIPTION
- Use of capital APPNAME is super confusing, particularly when
  environment variables for "app" are customarily capitalized as
  `APP_`.
- Various spelling and markup fixes.
