### PR TITLE
adding option to use rcconfig instead of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Configuration files may be in either `json` or `ini` format.
 Since ini, and env variables do not have a standard for types,
 your application needs be prepared for strings.
 
+# Alternative `--config`
+
+In order to not clash with programs already looking for a `--config` in your command line arguments, you may specify
+`--rcconfig` instead to point to your config file.
+
+If `--rcconfig` is provided, the `--config` argument is ignored.
+
 # License
 
 BSD / MIT / Apache2

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function (name, defaults, argv) {
     ) || {}
 
   var local = cc.find('.'+name+'rc')
+  var config = argv.rcconfig || argv.config
 
   return deepExtend.apply(null, [
     defaults,
@@ -28,7 +29,7 @@ module.exports = function (name, defaults, argv) {
     cc.json(join(home, '.config', name)),
     cc.json(join(home, '.' + name, 'config')),
     cc.json(join(home, '.' + name + 'rc')),
-    cc.json(local || argv.config),
+    cc.json(local || config),
     local ? {config: local} : null,
     cc.env(name + '_'),
     argv

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "browserify": "browser.js",
   "scripts": {
-    "test": "set -e; node test/test.js; node test/ini.js"
+    "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,0 +1,1 @@
+{ "name": "config" }

--- a/test/fixtures/rcconfig.json
+++ b/test/fixtures/rcconfig.json
@@ -1,0 +1,1 @@
+{ "name": "rcconfig" }

--- a/test/rcconfig.js
+++ b/test/rcconfig.js
@@ -1,0 +1,24 @@
+var assert = require('assert')
+
+function inspect(obj, depth) {
+  console.error(require('util').inspect(obj, false, depth || 5, true));
+}
+
+// plain --config
+var config = require('../')('rc' + 1, null, { 
+  config: __dirname + '/fixtures/config.json' 
+})
+
+console.log('Without providing --rcconfig, config is used:')
+inspect(config)
+assert.equal(config.name, 'config')
+
+// more specific --rcconfig
+config = require('../')('rc' + 1, null, { 
+  config: __dirname + '/fixtures/config.json',
+  rcconfig: __dirname + '/fixtures/rcconfig.json' 
+})
+
+console.log('When providing --rcconfig, rcconfig is used instead of config:')
+inspect(config)
+assert.equal(config.name, 'rcconfig')


### PR DESCRIPTION
- `--config` may clash with lots of other tools
- allowing to use `--rcconfig` and have `--config` ignored
