### PR TITLE
Use `strip-json-comments` to allow comments in JSON config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ dependsOn=0.10.0
 
 ```json
 {
+  // You can even comment your JSON, if you want
   "dependsOn": "0.10.0",
   "commands": {
     "www": "./commands/www",
@@ -99,6 +100,7 @@ dependsOn=0.10.0
 }
 ```
 
+Comments are stripped from JSON config via [strip-json-comments](https://github.com/sindresorhus/strip-json-comments).
 
 > Since ini, and env variables do not have a standard for types, your application needs be prepared for strings.
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 var fs   = require('fs')
 var ini  = require('ini')
 var path = require('path')
+var stripJsonComments = require('strip-json-comments')
 
 var parse = exports.parse = function (content, file) {
 
@@ -10,7 +11,7 @@ var parse = exports.parse = function (content, file) {
   //everything is ini. even json with a systax error.
 
   if((file && /\.json$/.test(file)) || /^\s*{/.test(content)) 
-    return JSON.parse(content)
+    return JSON.parse(stripJsonComments(content))
   return ini.parse(content)
 
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "minimist": "~0.0.7",
     "deep-extend": "~0.2.5",
+    "strip-json-comments": "0.1.x",
     "ini": "~1.1.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -29,3 +29,28 @@ console.log(customArgv)
 
 assert.equal(customArgv.option, false)
 assert.equal(customArgv.envOption, 24)
+
+var fs = require('fs')
+var path = require('path')
+var jsonrc = path.resolve('.' + n + 'rc');
+
+fs.writeFileSync(jsonrc, [
+  '{',
+    '// json overrides default',
+    '"option": false,',
+    '/* env overrides json */',
+    '"envOption": 24',
+  '}'
+].join('\n'));
+
+var commentedJSON = require('../')(n, {
+  option: true
+})
+
+fs.unlinkSync(jsonrc);
+
+console.log(commentedJSON)
+
+assert.equal(commentedJSON.option, false)
+assert.equal(commentedJSON.envOption, 42)
+assert.equal(commentedJSON.config, jsonrc)


### PR DESCRIPTION
Large JSON-formatted config files can get very unwieldy without comments, and feature parity with INI-formatted comments is a nice bonus. JSHint, king of gargantuan JSON config, switched to using this module [recently](https://github.com/jshint/jshint/pull/1580).

Incidentally, this also verifies the "local" .APPNAMErc pattern.
