### PR TITLE
Implements #23, report which config files were loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Given your application name (`appname`), rc will look in all the obvious places 
 All configuration sources that were found will be flattened into one object,
 so that sources **earlier** in this list override later ones.
 
+## Which files were loaded?
+
+The returned configuration object will have an non-enumerable array property `_rcfiles` that reports which files were loaded.
+
+```javascript
+var conf = require('rc')
+console.log('Loaded', conf._rcfiles)
+```
 
 ## Configuration File Formats
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,8 @@ var parse = exports.parse = function (content, file) {
 }
 
 var json = exports.json = function () {
-  var args = [].slice.call(arguments).filter(function (arg) { return arg != null })
+  var args = [].slice.call(arguments, 1).filter(function (arg) { return arg != null })
+  var files = arguments[0]
 
   //path.join breaks if it's a not a string, so just skip this.
   for(var i in args)
@@ -31,6 +32,9 @@ var json = exports.json = function () {
   } catch (err) {
     return
   }
+
+  files.push(file)
+
   return parse(content)
 }
 
@@ -94,4 +98,3 @@ var find = exports.find = function () {
   }
   return find(process.cwd(), rel)
 }
-

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "browserify": "browser.js",
   "scripts": {
-    "test": "set -e; node test/test.js; node test/ini.js; node test/nested-env-vars.js"
+    "test": "set -e; node test/test.js; node test/ini.js; node test/nested-env-vars.js; node test/files.js"
   },
   "repository": {
     "type": "git",

--- a/test/files.js
+++ b/test/files.js
@@ -1,0 +1,24 @@
+var fs = require('fs')
+var path = require('path')
+var n = 'rc'+Math.random()
+var assert = require('assert')
+var jsonrc = path.resolve('.' + n + 'rc')
+
+fs.writeFileSync(jsonrc, [
+  '{',
+    '"option": false,',
+    '"otherOption": 24',
+  '}'
+].join('\n'));
+
+var config = require('../')(n)
+
+fs.unlinkSync(jsonrc);
+
+console.log('\n\n------ report loaded configuration files ------\n', config)
+
+assert.equal(config._rcfiles.length, 1)
+assert.equal(config._rcfiles[0], jsonrc)
+
+// should not be enumerable
+assert.equal(Object.keys(config).indexOf('_rcfiles'), -1)


### PR DESCRIPTION
I've also run a situation similar to #23 where it would be useful to report which configuration files were actually loaded by rc, so have added support for a `_rcfiles` property to be added to the returned configuration object which contains the list of files, along with tests and a section documenting it in the readme.

It works by passing an array into the json util method - when it parses a json/ini file, it adds the name of the file to the list.  The list is then added to the configuration object as a non-enumerable property.

I hope this is helpful, please let me know if you have any comments.
