### PR TITLE
Use hasOwnProperty when iterating an array

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ var json = exports.json = function () {
 
   //path.join breaks if it's a not a string, so just skip this.
   for(var i in args)
-    if('string' !== typeof args[i])
+    if(args.hasOwnProperty(i) && 'string' !== typeof args[i])
       return
 
   var file = path.join.apply(null, args)


### PR DESCRIPTION
...nevermind. I'm an idiot, and this was my fault.

Granted, `hasOwnProperty` is still a good idea for `for in`.
