### PR TITLE
Hjson Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ so that sources **earlier** in this list override later ones.
 
 ## Configuration File Formats
 
-Configuration files (e.g. `.appnamerc`) may be in either [json](http://json.org/example) or [ini](http://en.wikipedia.org/wiki/INI_file) format. The example configurations below are equivalent:
+Configuration files (e.g. `.appnamerc`) may be in either [json](http://json.org/example), [Hjson](http://hjson.org/) or [ini](http://en.wikipedia.org/wiki/INI_file) format. The example configurations below are equivalent:
 
 
 #### Formatted as `ini`
@@ -102,6 +102,38 @@ dependsOn=0.10.0
 ```
 
 Comments are stripped from JSON config via [strip-json-comments](https://github.com/sindresorhus/strip-json-comments).
+
+#### Formatted as `Hjson`
+
+```hjson
+#hjson
+{
+  // Hjson does not fail on missing/trailing commas
+  // and other common JSON mistakes.
+  dependsOn: 0.10.0
+  commands:
+  {
+    www: ./commands/www
+    console: ./commands/repl
+  }
+  generators:
+  {
+    options:
+    {
+      engine: ejs
+    }
+    modules:
+    {
+      new: generate-new
+      backend: generate-backend
+    }
+  }
+}
+```
+
+The [Hjson](http://hjson.org/) parser is not a dependency of rc. The dependencies section of your package.json file must contain the `hjson` module in order to read and parse Hjson configs.
+
+Note the `#hjson` header is required.
 
 > Since ini, and env variables do not have a standard for types, your application needs be prepared for strings.
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@ var fs   = require('fs')
 var ini  = require('ini')
 var path = require('path')
 var stripJsonComments = require('strip-json-comments')
+var hjson = null // lazy require
 
 var parse = exports.parse = function (content, file) {
 
@@ -12,6 +13,13 @@ var parse = exports.parse = function (content, file) {
 
   if((file && /\.json$/.test(file)) || /^\s*{/.test(content)) 
     return JSON.parse(stripJsonComments(content))
+
+  if((file && /\.hjson$/.test(file)) || /^#hjson\n\s*{/.test(content)) {
+    if (!hjson)
+      hjson = require('hjson')
+    return hjson.parse(content)
+  }
+
   return ini.parse(content)
 
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "deep-extend": "~0.2.5",
     "strip-json-comments": "0.1.x",
     "ini": "~1.3.0"
+  },
+  "devDependencies": {
+    "hjson": "^1.6.1"
   }
 }


### PR DESCRIPTION
I've added support for Hjson. 

It's compatible with the current JSON + strip-comments but also supports a syntax specifically for config files that is less error prone. E.g. no trailing comma errors - for details see http://laktak.github.io/hjson/.

I'd appreciate if you could merge & publish to npm so we can use it with the [slap](https://github.com/slap-editor/slap) editor.