### PR TITLE
Don't add the same config file twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function (name, defaults, argv, parse) {
   var configs = [defaults]
   var configFiles = []
   function addConfigFile (file) {
+    if (configFiles.indexOf(file) >= 0) return
     var fileConfig = cc.file(file)
     if (fileConfig) {
       configs.push(parse(fileConfig))


### PR DESCRIPTION
`cc.find('.'+name+'rc')` may return with `~/.npmrc` config file which has already been added before. This results in `configs` array containing the same file more than once.

This patch fixes it by adding a check to `addConfigFile`.