### PR TITLE
Start search for rc file from running script and not from cwd

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -96,6 +96,6 @@ var find = exports.find = function () {
         return find(path.dirname(start), rel)
     }
   }
-  return find(process.cwd(), rel)
+  return find(__dirname, rel)
 }
 


### PR DESCRIPTION
I have a situation where the node application is being started from the root of the directory structure. 

App location:
`/home/guy/myapp/index.js`
Start location:
`/`

i.e. my app is started by using: `node home/guy/myapp/index.js`

This makes the `process.cwd()` start searching from the root so it never finds my app's rc file. If we change it to `__dirname` then it will start searching from (in my example) `/home/guy/myapp/node_modules/rc/lib/`. This would solve the problem.

Implication for other users of rc that are starting from the normal home directory of the app: So long as they didn't have an rc file for their application in `node_modules`, `node_modules/rc`, or `node_modules/rc/lib` then it will behave as normal. I can't think of a use case where they would have their app's rc file in any of those locations...
