### PR TITLE
update minimist

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "bin": "./index.js",
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
   "dependencies": {
-    "minimist": "~0.0.7",
+    "minimist": "^1.1.2",
     "deep-extend": "~0.2.5",
     "strip-json-comments": "0.1.x",
     "ini": "~1.3.0"


### PR DESCRIPTION
`rc` is using an old version of `minimist` and I'd like to be able to use minimist aliases, e.g.

```js
var minimist = require('minimist')

module.exports = require('rc')('myapp', {
  foo: 'foovalue',
  bar: 'barvalue'
}, minimist(process.argv, {
  alias: { foo: 'f', bar: 'b' }
}))
```

While I can always do this it's nice if rc uses the latest minimist so npm can dedupe properly whenever a dependant depends on both rc and minimist.

Alternatively I'd like to be able to somehow pass the aliases object into rc which in turn passes it to minimist.