### PR TITLE
Nested environment variables with unassigned empty level in between

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,7 @@ var env = exports.env = function (prefix, env) {
       while ((_emptyStringIndex=keypath.indexOf('')) > -1) {
         keypath.splice(_emptyStringIndex, 1)
       }
-      
+
       var cursor = obj
       keypath.forEach(function _buildSubObj(_subkey,i){
 
@@ -65,7 +65,7 @@ var env = exports.env = function (prefix, env) {
         // (unless it's just an empty string- in that case use the last valid key)
         if (i === keypath.length-1)
           cursor[_subkey] = env[k]
-          
+
 
         // Build sub-object if nothing already exists at the keypath
         if (cursor[_subkey] === undefined)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,8 @@ var env = exports.env = function (prefix, env) {
       keypath.forEach(function _buildSubObj(_subkey,i){
 
         // (check for _subkey first so we ignore empty strings)
-        if (!_subkey)
+        // (check for cursor to avoid assignment to primitive objects)
+        if (!_subkey || typeof cursor !== 'object')
           return
 
         // If this is the last key, just stuff the value in there

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+'use strict';
 var fs   = require('fs')
 var ini  = require('ini')
 var path = require('path')

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -7,6 +7,7 @@ var assert = require('assert')
 process.env[n+'_someOpt__a'] = 42
 process.env[n+'_someOpt__x__'] = 99
 process.env[n+'_someOpt__a__b'] = 186
+process.env[n+'_someOpt__a__b__c'] = 243
 process.env[n+'_someOpt__x__y'] = 1862
 process.env[n+'_someOpt__z'] = 186577
 


### PR DESCRIPTION
I had problems with `rc` trying to deal with nested environment variables that have a empty level in between such as  `project_someopt__a` and `project_someopt__a__b__c` (see environment variable added to testing code).

It turns out that the old code was assigning properties to primitive values and that was confusing. To prevent this from happening strict mode has been enabled.

To fix the problem found a new check to make sure the assignment only happens to objects seems to do the job. Note that a primitive value would mean that there has been already an assignment at an upper lever and hence the following ones are expected to be ignored as is indeed checked in the testing code.