### PR TITLE
Feature/env uppercase

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,8 +43,9 @@ var env = exports.env = function (prefix, env) {
   env = env || process.env
   var obj = {}
   var l = prefix.length
+  var regex = new RegExp("^"+prefix, "i");
   for(var k in env) {
-    if((k.indexOf(prefix)) === 0) {
+    if(regex.test(k)) {
 
       var keypath = k.substring(l).split('__')
 

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -1,5 +1,7 @@
 
-var n = 'rc'+Math.random()
+var seed = Math.random();
+var n = 'rc'+ seed;
+var N = 'RC'+ seed;
 var assert = require('assert')
 
 
@@ -17,6 +19,9 @@ process.env[n+'_someOpt__w__w__'] = 18629
 
 // Leading '__' should ignore everything up to 'z'
 process.env[n+'___z__i__'] = 9999
+
+// should ignore case for config name section.
+process.env[N+'_test_upperCase'] = 187
 
 var config = require('../')(n, {
   option: true
@@ -37,4 +42,5 @@ assert.equal(config.someOpt.z/*.x*/, 186577)
 assert.equal(config.someOpt.w.w, 18629)
 assert.equal(config.z.i, 9999)
 
+assert.equal(config.test_upperCase, 187)
 


### PR DESCRIPTION
This PR allow for the appname prefix passed to `rc` to be case insensitive in `ENV` variables. Rational is most ENV keys are uppercase, this at least allows the namespace to be uppercased without effecting other aspects of values being passed.

Added a test case & tests pass.
