### PR TITLE
Support for .${appname}config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ Given your application name (`appname`), rc will look in all the obvious places 
   * environment variables prefixed with `${appname}_`
     * or use "\_\_" to indicate nested properties <br/> _(e.g. `appname_foo__bar__baz` => `foo.bar.baz`)_
   * if you passed an option `--config file` then from that file
-  * a local `.${appname}rc` or the first found looking in `./ ../ ../../ ../../../` etc.
+  * a local `.${appname}rc` and `.${appname}config` or the first found looking in `./ ../ ../../ ../../../` etc.
   * `$HOME/.${appname}rc`
+  * `$HOME/.${appname}config`
   * `$HOME/.${appname}/config`
   * `$HOME/.config/${appname}`
   * `$HOME/.config/${appname}/config`
   * `/etc/${appname}rc`
+  * `/etc/${appname}config`
   * `/etc/${appname}/config`
   * the defaults object you passed in.
 
@@ -141,7 +143,7 @@ such as strict, valid JSON only.
 
 ## Note on Performance
 
-`rc` is running `fs.statSync`-- so make sure you don't use it in a hot code path (e.g. a request handler) 
+`rc` is running `fs.statSync`-- so make sure you don't use it in a hot code path (e.g. a request handler)
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -36,13 +36,17 @@ module.exports = function (name, defaults, argv, parse) {
   // which files do we look at?
   if (!win)
    [join(etc, name, 'config'),
+    join(etc, name + 'config'),
     join(etc, name + 'rc')].forEach(addConfigFile)
-  if (home)
+  if (home) {
    [join(home, '.config', name, 'config'),
     join(home, '.config', name),
     join(home, '.' + name, 'config'),
+    join(home, '.' + name + 'config'),
     join(home, '.' + name + 'rc')].forEach(addConfigFile)
-  addConfigFile(cc.find('.'+name+'rc'))
+  }
+ [cc.find('.'+name+'config'),
+  cc.find('.'+name+'rc')].forEach(addConfigFile)
   if (env.config) addConfigFile(env.config)
   if (argv.config) addConfigFile(argv.config)
 


### PR DESCRIPTION
`rc` does not support parsing of .${appname}config files. For example, I try to use `rc` to parse `.gitconfig` file.

What do you think about this?