### PR TITLE
In win32 platform, %APPDATA%\npm\etc\ should coresspond to /etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@
 var cc   = require('./lib/utils')
 var join = require('path').join
 var deepExtend = require('deep-extend')
-var etc = '/etc'
 var win = process.platform === "win32"
+var etc = win
+           ? join(process.env.APPDATA, 'npm', 'etc')
+           : '/etc'
 var home = win
            ? process.env.USERPROFILE
            : process.env.HOME
@@ -34,7 +36,7 @@ module.exports = function (name, defaults, argv, parse) {
   }
 
   // which files do we look at?
-  if (!win)
+  if (etc)
    [join(etc, name, 'config'),
     join(etc, name + 'rc')].forEach(addConfigFile)
   if (home)


### PR DESCRIPTION
Global settings of npm are not referenced in win32 platform.
'npm config --global' refers to %APPDIR%\npm\etc\npmrc, so %APPDATA%\npm\etc\ should coresspond to /etc.