### PR TITLE
Update strip-json-comments dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "deep-extend": "~0.4.0",
     "ini": "~1.3.0",
     "minimist": "^1.2.0",
-    "strip-json-comments": "~1.0.4"
+    "strip-json-comments": "~2.0.1"
   }
 }


### PR DESCRIPTION
I updated a dependency, since an old major release was used, used with a tilde preventing upgrading to v2, even though v2 has the same API regarding use in this project.

The old version of the dependency is inferior because it has a 'return' statement outside of a function, which is a SyntaxError in strict mode, which is mandated by ES2015.