### PR TITLE
Add support for JSON array/object notation in env variables

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,8 +65,15 @@ var env = exports.env = function (prefix, env) {
         // If this is the last key, just stuff the value in there
         // Assigns actual value from env variable to final key
         // (unless it's just an empty string- in that case use the last valid key)
-        if (i === keypath.length-1)
-          cursor[_subkey] = env[k]
+        if (i === keypath.length-1) {
+          var result
+          try {
+            result = JSON.parse(env[k])
+          } catch (err) {
+            result = env[k]
+          }
+          cursor[_subkey] = result
+        }
 
 
         // Build sub-object if nothing already exists at the keypath

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "hardwired configuration loader",
   "main": "index.js",
   "browserify": "browser.js",

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -32,6 +32,7 @@ process.env[n+'_string__undefined'] = 'undefined'
 process.env[n+'_string__null'] = 'null'
 process.env[n+'_string__object'] = '{ "test": true }'
 process.env[n+'_string__array'] = '[1,2,3]'
+process.env[n+'_string__version'] = '0.10.0'
 
 function testPrefix(prefix) {
 	var config = require('../')(prefix, {
@@ -71,6 +72,8 @@ function testPrefix(prefix) {
 	assert.equal(typeof config.string.object, 'object')
 	assert.deepStrictEqual(config.string.array, [1, 2, 3])
 	assert.equal(typeof config.string.array, 'object')
+	assert.deepStrictEqual(config.string.version, '0.10.0')
+	assert.equal(typeof config.string.version, 'string')
 }
 
 testPrefix(n);

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -23,6 +23,15 @@ process.env[n+'___z__i__'] = 9999
 // should ignore case for config name section.
 process.env[N+'_test_upperCase'] = 187
 
+// Should parse strings
+process.env[n+'_string__number'] = '-0.2432423'
+process.env[n+'_string__boolean'] = 'false'
+process.env[n+'_string__string'] = '_test'
+process.env[n+'_string__empty'] = ''
+process.env[n+'_string__undefined'] = 'undefined'
+process.env[n+'_string__null'] = 'null'
+process.env[n+'_string__object'] = '{ test: "true" }'
+
 function testPrefix(prefix) {
 	var config = require('../')(prefix, {
 	  option: true
@@ -44,6 +53,21 @@ function testPrefix(prefix) {
 	assert.equal(config.z.i, 9999)
 
 	assert.equal(config.test_upperCase, 187)
+
+	assert.equal(config.string.number, -0.2432423)
+	assert.equal(typeof config.string.number, 'number')
+	assert.equal(config.string.boolean, false)
+	assert.equal(typeof config.string.boolean, 'boolean')
+	assert.equal(config.string.string, '_test')
+	assert.equal(typeof config.string.string, 'string')
+	assert.equal(config.string.empty, '')
+	assert.equal(typeof config.string.empty, 'string')
+	assert.equal(config.string.undefined, 'undefined')
+	assert.equal(typeof config.string.undefined, 'string')
+	assert.equal(config.string.null, null)
+	assert.equal(typeof config.string.null, 'object')
+	assert.equal(config.string.object, '{ test: "true" }')
+	assert.equal(typeof config.string.object, 'string')
 }
 
 testPrefix(n);

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -30,7 +30,7 @@ process.env[n+'_string__string'] = '_test'
 process.env[n+'_string__empty'] = ''
 process.env[n+'_string__undefined'] = 'undefined'
 process.env[n+'_string__null'] = 'null'
-process.env[n+'_string__object'] = '{ test: "true" }'
+process.env[n+'_string__object'] = '{ "test": true }'
 process.env[n+'_string__array'] = '[1,2,3]'
 
 function testPrefix(prefix) {
@@ -67,8 +67,8 @@ function testPrefix(prefix) {
 	assert.equal(typeof config.string.undefined, 'string')
 	assert.strictEqual(config.string.null, null)
 	assert.equal(typeof config.string.null, 'object')
-	assert.strictEqual(config.string.object, '{ test: "true" }')
-	assert.equal(typeof config.string.object, 'string')
+	assert.deepStrictEqual(config.string.object, { test: true })
+	assert.equal(typeof config.string.object, 'object')
 	assert.deepStrictEqual(config.string.array, [1, 2, 3])
 	assert.equal(typeof config.string.array, 'object')
 }

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -54,19 +54,19 @@ function testPrefix(prefix) {
 
 	assert.equal(config.test_upperCase, 187)
 
-	assert.equal(config.string.number, -0.2432423)
+	assert.strictEqual(config.string.number, -0.2432423)
 	assert.equal(typeof config.string.number, 'number')
-	assert.equal(config.string.boolean, false)
+	assert.strictEqual(config.string.boolean, false)
 	assert.equal(typeof config.string.boolean, 'boolean')
-	assert.equal(config.string.string, '_test')
+	assert.strictEqual(config.string.string, '_test')
 	assert.equal(typeof config.string.string, 'string')
-	assert.equal(config.string.empty, '')
+	assert.strictEqual(config.string.empty, '')
 	assert.equal(typeof config.string.empty, 'string')
-	assert.equal(config.string.undefined, 'undefined')
+	assert.strictEqual(config.string.undefined, 'undefined')
 	assert.equal(typeof config.string.undefined, 'string')
-	assert.equal(config.string.null, null)
+	assert.strictEqual(config.string.null, null)
 	assert.equal(typeof config.string.null, 'object')
-	assert.equal(config.string.object, '{ test: "true" }')
+	assert.strictEqual(config.string.object, '{ test: "true" }')
 	assert.equal(typeof config.string.object, 'string')
 }
 

--- a/test/nested-env-vars.js
+++ b/test/nested-env-vars.js
@@ -31,6 +31,7 @@ process.env[n+'_string__empty'] = ''
 process.env[n+'_string__undefined'] = 'undefined'
 process.env[n+'_string__null'] = 'null'
 process.env[n+'_string__object'] = '{ test: "true" }'
+process.env[n+'_string__array'] = '[1,2,3]'
 
 function testPrefix(prefix) {
 	var config = require('../')(prefix, {
@@ -68,6 +69,8 @@ function testPrefix(prefix) {
 	assert.equal(typeof config.string.null, 'object')
 	assert.strictEqual(config.string.object, '{ test: "true" }')
 	assert.equal(typeof config.string.object, 'string')
+	assert.deepStrictEqual(config.string.array, [1, 2, 3])
+	assert.equal(typeof config.string.array, 'object')
 }
 
 testPrefix(n);


### PR DESCRIPTION
In the current version, if an array is defined in an rc, there is no way to override it from env variables. This adds support for this. New version number since this risks breaking existing configurations.