### PR TITLE
Uses the standard browser field instead of the browserify field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "description": "hardwired configuration loader",
   "main": "index.js",
-  "browserify": "browser.js",
+  "browser": "browser.js",
   "scripts": {
     "test": "set -e; node test/test.js; node test/ini.js; node test/nested-env-vars.js"
   },


### PR DESCRIPTION
This pull request replaces the `browserify` field with the `browser` field in `package.json`. This allow the `rc` module to be compatible with any bundler (including [`browserify`] and [`webpack`]) that follows this [spec].

[`browserify`]: https://github.com/browserify/browserify#browser-field
[`webpack`]: https://webpack.js.org/configuration/resolve/#resolve-mainfields
[spec]: https://github.com/defunctzombie/package-browser-field-spec