### PR TITLE
Add support for /usr/local/etc/app.config

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ module.exports = function (name, defaults, argv, parse) {
   if (!win)
    [join(etc, name, 'config'),
     join(etc, name + 'rc'),
-    join(etc, name + '.config'),
+    join(etc, name + '.conf'),
     join(localEtc, name, 'config'),
     join(localEtc, name + 'rc'),
-    join(localEtc, name + '.config')].forEach(addConfigFile)
+    join(localEtc, name + '.conf')].forEach(addConfigFile)
   if (home)
    [join(home, '.config', name, 'config'),
     join(home, '.config', name),

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var cc   = require('./lib/utils')
 var join = require('path').join
 var deepExtend = require('deep-extend')
 var etc = '/etc'
+var localEtc = '/usr/local/etc'
 var win = process.platform === "win32"
 var home = win
            ? process.env.USERPROFILE
@@ -35,7 +36,11 @@ module.exports = function (name, defaults, argv, parse) {
   // which files do we look at?
   if (!win)
    [join(etc, name, 'config'),
-    join(etc, name + 'rc')].forEach(addConfigFile)
+    join(etc, name + 'rc'),
+    join(etc, name + '.config'),
+    join(localEtc, name, 'config'),
+    join(localEtc, name + 'rc')
+    join(localEtc, name + '.config')].forEach(addConfigFile)
   if (home)
    [join(home, '.config', name, 'config'),
     join(home, '.config', name),

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function (name, defaults, argv, parse) {
     join(etc, name + 'rc'),
     join(etc, name + '.config'),
     join(localEtc, name, 'config'),
-    join(localEtc, name + 'rc')
+    join(localEtc, name + 'rc'),
     join(localEtc, name + '.config')].forEach(addConfigFile)
   if (home)
    [join(home, '.config', name, 'config'),


### PR DESCRIPTION
A lot of non-linux systems (*BSD, MacOS...) keep non-base config files in /usr/local/etc, and it's a also a convention to support appname.conf as a filename in these directories, rather than just appending rc.

I'm suggesting it would be good to support that in this module, as it'd allow more closely aligning the conventions supported with what's expected on some platforms.