### PR TITLE
Recommendation for converting string representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Comments are stripped from JSON config via [strip-json-comments](https://github.
 
 > Since ini, and env variables do not have a standard for types, your application needs be prepared for strings.
 
-To ensure that booleans and numbers are always converted into their proper types (especially useful if you intend to do strict `===` comparisons), consider using a module such as [parse-strings-in-object](https://github.com/anselanza/parse-strings-in-object) to wrap the config object returned from rc.
+To ensure that string representations of booleans and numbers are always converted into their proper types (especially useful if you intend to do strict `===` comparisons), consider using a module such as [parse-strings-in-object](https://github.com/anselanza/parse-strings-in-object) to wrap the config object returned from rc.
 
 
 ## Simple example demonstrating precedence

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Comments are stripped from JSON config via [strip-json-comments](https://github.
 
 > Since ini, and env variables do not have a standard for types, your application needs be prepared for strings.
 
+To ensure that booleans and numbers are always converted into their proper types (especially useful if you intend to do strict `===` comparisons), consider using a module such as [parse-strings-in-object](https://github.com/anselanza/parse-strings-in-object) to wrap the config object returned from rc.
+
 
 ## Simple example demonstrating precedence
 Assume you have an application like this (notice the hard-coded defaults passed to rc):


### PR DESCRIPTION
As discussed in https://github.com/dominictarr/rc/issues/107, I have added a brief note in the docs about using a module to convert string representations of booleans and numbers in the returned config object, as an option.