### PR TITLE
update minimist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "deep-extend": "^0.6.0",
     "ini": "~1.3.0",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.3",
     "strip-json-comments": "~2.0.1"
   }
 }


### PR DESCRIPTION
minimist  before 1.2.2 could be tricked into adding or modifying properties of  Object.prototype using a "constructor" or "__proto__" payload.



